### PR TITLE
remove comma that converted path info from string to a tuple

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -559,7 +559,7 @@ def create_new_failure_records(request, failures):
     ip = get_ip(request)
     ua = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
     username = request.POST.get(USERNAME_FORM_FIELD, None)
-    path_info = request.META.get('PATH_INFO', '<unknown>'),
+    path_info = request.META.get('PATH_INFO', '<unknown>')
 
     # Record failed attempt. Whether or not the IP address or user agent is
     # used in counting failures is handled elsewhere, so we just record


### PR DESCRIPTION
In a previous PR (https://github.com/QuorumUS/quorum-site/pull/12593) I attempted to fix login flow for Internet Explorer users. One way I solved the issue was to have the login endpoint return a 200 status code upon successful login instead of a 302 status code. This is because Internet Explorer treated 302 status codes as errors.

However, Django Axes regarded 200 status codes as errors because it expects a successful login would 302 and redirect users to a different page. To resolve this, I manually called `axes.util.reset` for the specific username. This resulted in the `path_info` field on the corresponding AccessAttempt object being set to `(u'/login/',)` instead of the expected `/login/`.

After digging through the source code, I found the cause of that error:
```
path_info = request.META.get('PATH_INFO', '<unknown>'),
```
A string followed by a comma is converted into a tuple by Django. I believe this was an unintentional mistake by the maintainers. Directly below this line, an AccessAttempt object is created with the `path_info`
```
    AccessAttempt.objects.create(
		...
        path_info=path_info,
		...
	)
```
And the `path_info` field was only intended to be a CharField, as specified in `axes/models.py`.
```
    path_info = models.CharField(
        verbose_name='Path',
        max_length=255,
    )
```

I believe we should use the `release-2.3.3` branch of this fork is because Django 1.11 is required for the latest releases of Django Axes. And (besides this issue) version 2.3.3 has been stable and functioning with our application. 