### PR TITLE
login-status-code

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -307,7 +307,8 @@ def is_login_failed(response):
     return (
         response and
         not response.has_header('location') and
-        response.status_code != 302
+        response.status_code != 302 and
+        response.status_code != 200
     )
 
 def is_ajax_login_failed(response):


### PR DESCRIPTION
## Technical Details
- Change login failed check to count 200 status codes as login successful
- Currently, when somebody logs in successfully, their access attempts are reset to 0, and then the current login is counted as a failure and their access attempts are set to 1. I mistakenly thought this wouldn't be an issue, and that users would just have 19 failed login attempts to reach the limit instead of the normal 20. However, there is also an IP check across all users for 20 failed logins. This meant if 20 people successfully logs in within an hour, the cap would be reached. 